### PR TITLE
feat: add modal closing example and reorganize modal category

### DIFF
--- a/src/components/articles/ux-speed-game/ResultsSection.tsx
+++ b/src/components/articles/ux-speed-game/ResultsSection.tsx
@@ -12,7 +12,7 @@ const FRICTIONS = [
     title: "Modal closing",
     bad: "Only the X button works",
     good: "X button + click outside + Escape key",
-    link: null,
+    link: "/example/modal-closing",
   },
   {
     title: "Code copy",

--- a/src/examples/autofocus-modal/index.ts
+++ b/src/examples/autofocus-modal/index.ts
@@ -9,7 +9,7 @@ export const meta = {
   title: "Autofocus on Modal input",
   description:
     "When a modal opens with a single input, it should be automatically focused",
-  category: "Forms",
+  category: "Modals",
   tags: ["modal", "input", "accessibility", "mobile"],
 };
 

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -9,9 +9,11 @@ import * as formValidationFeedback from "./form-validation-feedback";
 import * as inputAutoFormat from "./input-auto-format";
 import * as scrollToTop from "./scroll-to-top";
 import * as pasteOtpCode from "./paste-otp-code";
+import * as modalClosing from "./modal-closing";
 
 export const examples = [
   autofocusModal,
+  modalClosing,
   submitButtonLoading,
   verificationCodeInput,
   copyFeedback,

--- a/src/examples/modal-closing/BadExample.tsx
+++ b/src/examples/modal-closing/BadExample.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function BadExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="default">Open modal</Button>
+      </DialogTrigger>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Delete item</DialogTitle>
+          <DialogDescription>
+            Only the X button works. Try clicking outside or pressing Escape.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <p className="text-sm">
+            This modal can only be closed by clicking the X button in the top
+            right corner. Clicking outside the modal or pressing the Escape key
+            won't work.
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => setOpen(false)}>
+            Delete
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/examples/modal-closing/GoodExample.tsx
+++ b/src/examples/modal-closing/GoodExample.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function GoodExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="default">Open modal</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete item</DialogTitle>
+          <DialogDescription>
+            Multiple ways to close: X button, click outside, or press Escape.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <p className="text-sm">
+            This modal can be closed in three ways: clicking the X button,
+            clicking outside the modal, or pressing the Escape key. This gives
+            users flexibility and matches their expectations.
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => setOpen(false)}>
+            Delete
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/examples/modal-closing/README.md
+++ b/src/examples/modal-closing/README.md
@@ -1,0 +1,64 @@
+# Modal Closing
+
+## Description
+
+A modal should provide multiple ways to close: clicking the X button, clicking outside the modal (on the overlay), and pressing the Escape key. This gives users flexibility and matches their expectations across different contexts and preferences.
+
+## Why it matters
+
+- **User autonomy**: Different users have different preferences for how they interact with modals
+- **Accessibility**: Keyboard users rely on the Escape key, while mouse users might prefer clicking outside
+- **Efficiency**: Power users can quickly dismiss modals with Escape without moving their mouse
+- **Mobile-friendly**: On touch devices, tapping outside is often more natural than hitting a small X button
+- **Reduced frustration**: Being "trapped" in a modal with only one exit method creates unnecessary friction
+
+## The psychology behind it
+
+When a modal appears, users instinctively try multiple methods to close it based on their past experiences. Some users immediately reach for the Escape key, others click outside, and some look for the close button. By supporting all three methods, you respect these learned behaviors and create a frictionless experience.
+
+Restricting closure to only one method (like the X button) breaks user expectations and can make the interface feel rigid and controlling. This is particularly frustrating on mobile devices where the X button can be small and hard to tap accurately.
+
+## When to apply
+
+- Standard modals (forms, dialogs, lightboxes)
+- Informational pop-ups
+- Settings panels
+- Image galleries and previews
+- Quick action sheets
+- Most modal interactions where the user might want to cancel or go back
+
+## When not to apply
+
+- Critical confirmations where accidental closure could be problematic (e.g., "You have unsaved changes" warnings)
+- Multi-step wizards where clicking outside might indicate confusion rather than intent to close
+- Loading states or processing modals that should not be dismissed mid-operation
+- Forced acknowledgment dialogs (though these should be used sparingly)
+
+In these cases, you might disable click-outside or Escape, but **always** provide a clear "Cancel" or "Close" button as an explicit exit option.
+
+## Implementation tips
+
+1. **Default behavior**: Most UI libraries (Radix UI, Headless UI, Material UI) support all three closing methods by default
+2. **Consistent behavior**: If you disable one method, make sure users understand why (e.g., show a message explaining they need to save or cancel)
+3. **Visual feedback**: When clicking outside, consider adding a subtle shake or highlight to the modal to indicate the interaction was registered
+4. **Focus management**: When the modal closes, return focus to the element that opened it (important for keyboard navigation)
+5. **Animation**: Ensure the closing animation is smooth and consistent regardless of how the modal was closed
+
+## Common patterns
+
+**Standard dialog**:
+- X button ✓
+- Click outside ✓
+- Escape key ✓
+
+**Confirmation dialog with unsaved changes**:
+- X button (shows "are you sure?" prompt)
+- Click outside (shows "are you sure?" prompt)
+- Escape key (shows "are you sure?" prompt)
+- "Cancel" and "Confirm" buttons
+
+**Loading modal**:
+- X button ✗
+- Click outside ✗
+- Escape key ✗
+- Automatically closes when loading completes

--- a/src/examples/modal-closing/index.ts
+++ b/src/examples/modal-closing/index.ts
@@ -1,0 +1,22 @@
+import { GoodExample } from "./GoodExample";
+import { BadExample } from "./BadExample";
+import content from "./README.md?raw";
+
+export { content };
+
+export const meta = {
+  id: "modal-closing",
+  title: "Modal closing",
+  description:
+    "A modal should provide multiple ways to close: X button, click outside, and Escape key",
+  category: "Modals",
+  tags: ["modal", "accessibility", "keyboard", "ux"],
+};
+
+export const BadExamples = [
+  { component: BadExample, label: "Only X button works" },
+];
+
+export const GoodExamples = [
+  { component: GoodExample, label: "X + click outside + Escape" },
+];


### PR DESCRIPTION
Add new modal-closing example demonstrating proper modal UX patterns:
- Bad example: only X button works for closing
- Good example: X button + click outside + Escape key

Also includes:
- Detailed README with UX explanations and best practices
- Integration in UX Speed Game with link to example
- Reorganize autofocus-modal to "Modals" category (was "Forms")