### PR TITLE
fix: improve radio button dark mode contrast

### DIFF
--- a/src/examples/display-options/GoodExample.tsx
+++ b/src/examples/display-options/GoodExample.tsx
@@ -81,7 +81,7 @@ export function GoodExampleCards() {
               )}
             >
               {selected === plan.id && (
-                <div className="h-1.5 w-1.5 rounded-full bg-white" />
+                <div className="h-1.5 w-1.5 rounded-full bg-primary-foreground" />
               )}
             </div>
             <div className="grid gap-0.5">


### PR DESCRIPTION
Replace bg-white with bg-primary-foreground for the radio button's inner circle to ensure proper contrast in both light and dark modes