### PR TITLE
chore: update domain from netlify to uxgoodpatterns.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UX Good Patterns
 
-**[Live Demo](https://ux-good-patterns.netlify.app/)**
+**[Live Demo](https://uxgoodpatterns.com/)**
 
 An open source collection of UX patterns with comparative examples. Each pattern shows a "good" and "bad" example to illustrate user experience best practices.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";
 
 export default defineConfig({
-  site: "https://ux-good-patterns.netlify.app",
+  site: "https://uxgoodpatterns.com",
   output: "static",
   integrations: [react(), sitemap(), mdx()],
   vite: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://ux-good-patterns.netlify.app/sitemap-index.xml
+Sitemap: https://uxgoodpatterns.com/sitemap-index.xml

--- a/public/ux-rules.md
+++ b/public/ux-rules.md
@@ -1,6 +1,6 @@
 # UX Best Practices for AI-Assisted Development
 
-> Auto-generated from https://ux-good-patterns.netlify.app
+> Auto-generated from https://uxgoodpatterns.com
 
 ## Instructions for AI
 

--- a/scripts/generate-ai-context.ts
+++ b/scripts/generate-ai-context.ts
@@ -61,7 +61,7 @@ function generateAiContext(): void {
   // Header
   lines.push("# UX Best Practices for AI-Assisted Development");
   lines.push("");
-  lines.push("> Auto-generated from https://ux-good-patterns.netlify.app");
+  lines.push("> Auto-generated from https://uxgoodpatterns.com");
   lines.push("");
   lines.push("## Instructions for AI");
   lines.push("");

--- a/src/components/AiContextActions.tsx
+++ b/src/components/AiContextActions.tsx
@@ -1,7 +1,7 @@
 import { Check, Copy, Download, Link } from "lucide-react";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
-const FILE_URL = "https://ux-good-patterns.netlify.app/ux-rules.md";
+const FILE_URL = "https://uxgoodpatterns.com/ux-rules.md";
 
 export function AiContextActions() {
   const { copied: copiedLink, copy: copyLink } = useCopyToClipboard();

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -36,7 +36,7 @@ import { CopyableUrl } from "@/components/CopyableUrl";
             Just give it the link. Works with Claude, ChatGPT with browsing, and similar tools.
           </p>
           <div class="ml-8">
-            <CopyableUrl url="https://ux-good-patterns.netlify.app/ux-rules.md" client:load />
+            <CopyableUrl url="https://uxgoodpatterns.com/ux-rules.md" client:load />
           </div>
         </div>
 


### PR DESCRIPTION
Update all references to the old domain (ux-good-patterns.netlify.app)
to the new custom domain (uxgoodpatterns.com) for share button URLs
and other references throughout the codebase.